### PR TITLE
New web API for sysadmin to share base to person

### DIFF
--- a/src/dtable-web-api.js
+++ b/src/dtable-web-api.js
@@ -4655,6 +4655,40 @@ class DTableWebAPI {
     return this.req.get(url);
   }
 
+  sysAdminGetSharePermissions(dtableUuid) {
+    const url = this.server + "/api/v2.1/admin/dtables/share-permissions/"+dtableUuid+"/";
+    return this.req.get(url);
+  }
+
+  sysAdminListTableShares(dtableUuid) {
+    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
+    return this.req.get(url);
+  }
+
+  sysAdminAddTableShare(dtableUuid, email, permission) {
+    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
+    let params = {
+      email: email,
+      permission: permission
+    };
+    return this.req.post(url, params);
+  }
+
+  sysAdminDeleteTableShare(dtableUuid, email) {
+    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
+    let params = { email: email };
+    return this.req.delete(url, { data: params });
+  }
+
+  sysAdminUpdateTableShare(dtableUuid, email, permission) {
+    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
+    let params = {
+      email: email,
+      permission: permission
+    };
+    return this.req.put(url, params);
+  }
+
   sysAdminCopyDTable(srcWorkspaceID, dstWorkspaceID, name) {
     const url = this.server + '/api/v2.1/admin/dtable-copy/';
     let formData = new FormData();
@@ -4670,6 +4704,7 @@ class DTableWebAPI {
     formData.append('dst_dtable_uuid', dst_dtable_uuid);
     return this._sendPostRequest(url, formData);
   }
+
 
   sysAdminAddRepoSharedItem(repoID, shareType, shareToList, permission) {
     const url = this.server + '/api/v2.1/admin/shares/';

--- a/src/dtable-web-api.js
+++ b/src/dtable-web-api.js
@@ -4656,37 +4656,37 @@ class DTableWebAPI {
   }
 
   sysAdminGetSharePermissions(dtableUuid) {
-    const url = this.server + "/api/v2.1/admin/dtables/share-permissions/"+dtableUuid+"/";
+    const url = this.server + '/api/v2.1/admin/dtables/share-permissions/' + dtableUuid + '/';
     return this.req.get(url);
   }
 
   sysAdminListTableShares(dtableUuid) {
-    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
+    const url = this.server + '/api/v2.1/admin/dtables/share/' + dtableUuid + '/';
     return this.req.get(url);
   }
 
   sysAdminAddTableShare(dtableUuid, email, permission) {
-    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
-    let params = {
+    const url = this.server + '/api/v2.1/admin/dtables/share/' + dtableUuid + '/';
+    let data = {
       email: email,
       permission: permission
     };
-    return this.req.post(url, params);
+    return this.req.post(url, data);
   }
 
   sysAdminDeleteTableShare(dtableUuid, email) {
-    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
+    const url = this.server + '/api/v2.1/admin/dtables/share/' + dtableUuid + '/';
     let params = { email: email };
     return this.req.delete(url, { data: params });
   }
 
   sysAdminUpdateTableShare(dtableUuid, email, permission) {
-    const url = this.server + "/api/v2.1/admin/dtables/share/"+dtableUuid+"/";
-    let params = {
+    const url = this.server + '/api/v2.1/admin/dtables/share/' + dtableUuid + '/';
+    let data = {
       email: email,
       permission: permission
     };
-    return this.req.put(url, params);
+    return this.req.put(url, data);
   }
 
   sysAdminCopyDTable(srcWorkspaceID, dstWorkspaceID, name) {


### PR DESCRIPTION
1. **sysAdminGetSharePermissions**: returns the share permissions of the base, with argument **uuid of the base**
2. **sysAdminListTableShares**: lists all users in sharing status of a base, with argument **uuid of the base**
3. **sysAdminAddTableShare**: add a user with permission in sharing status, with arguments **uuid, email, permission**
4. **sysAdminDeleteTableShare**: delete a user's sharing status to a base, with arguments **uuid, email**
5. **sysAdminUpdateTableShare**: modify a user's sharing permission to a base, with arguments **uuid, email, permission**